### PR TITLE
Adds JsonAttrsMixin

### DIFF
--- a/jsonattrs/mixins.py
+++ b/jsonattrs/mixins.py
@@ -1,0 +1,16 @@
+from jsonattrs.models import Schema
+
+
+class JsonAttrsMixin:
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+
+        obj = self.object
+        field = self.attributes_field
+        obj_attrs = getattr(obj, field)
+
+        schemas = Schema.objects.from_instance(obj)
+        attrs = [a for s in schemas for a in s.attributes.all()]
+        context[field] = [(a.long_name, obj_attrs.get(a.name, '—'))
+                          for a in attrs if not a.omit]
+        return context

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,0 +1,52 @@
+from django.test import TestCase
+from django.views.generic import TemplateView
+
+from django.contrib.contenttypes.models import ContentType
+from jsonattrs import models, mixins
+
+from . import factories
+
+
+class JsonAttrsView(mixins.JsonAttrsMixin, TemplateView):
+    attributes_field = 'attrs'
+
+
+class JsonAttrsMixinTest(TestCase):
+    def test_get_context(self):
+        models.create_attribute_types()
+        org = factories.OrganizationFactory.create()
+        project = factories.ProjectFactory.create(organization=org)
+        content_type = ContentType.objects.get(
+            app_label='tests', model='party')
+
+        schema1 = models.Schema.objects.create(
+            content_type=content_type,
+            selectors=(org.id, project.id))
+
+        models.Attribute.objects.create(
+            schema=schema1,
+            name='field_1',
+            long_name='Field 1',
+            attr_type=models.AttributeType.objects.get(name='text'),
+            index=0
+        )
+        models.Attribute.objects.create(
+            schema=schema1,
+            name='field_2',
+            long_name='Field 2',
+            attr_type=models.AttributeType.objects.get(name='text'),
+            index=1
+        )
+
+        party = factories.PartyFactory.create(
+            project=project,
+            attrs={'field_1': 'Some value'}
+        )
+
+        view = JsonAttrsView()
+        view.object = party
+        context = view.get_context_data()
+        assert len(context['attrs']) == 2
+
+        assert context['attrs'][0] == ('Field 1', 'Some value')
+        assert context['attrs'][1] == ('Field 2', '—')


### PR DESCRIPTION
Adds a mixin for Django’s [DetailView](https://docs.djangoproject.com/en/1.9/ref/class-based-views/generic-display/#detailview) that adds attribute values to the template context, so they can be displayed in the template. 
## Usage
### View setup

``` python
from django.views import generic
from jsonattrs.mixins import JsonAttrsMixin

class LocationDetail(JsonAttrsMixin, generic.DetailView):
    attributes_field = 'attrs'
```
### Display attributes in template

The template context provides the attributes in a field that corresponds to the name set in the view's `attributes_field` as a list of tuples, for example:

``` python
{
    # Other context data
    'attrs': [
        ('Field long name', 'Field value'),
        ('Other field long name', 'Other field value')
    ]
}
```

``` html
{% for attr in attrs %}
<tr>
  <td><strong>{{ attr.0 }}</strong></td>
  <td>{{ attr.1 }}</td>
</tr>
{% endfor %}
```
