### PR TITLE
Added support for select_multiple

### DIFF
--- a/example/exampleapp/management/commands/loadtestdata.py
+++ b/example/exampleapp/management/commands/loadtestdata.py
@@ -174,7 +174,12 @@ SPECIFIC_SCHEMATA = [
           'attr_type': 'select_one',
           'choices': ['-', 'A', 'J', 'M'],
           'choice_labels': ['None', 'Apprentice', 'Journeyman', 'Master'],
-          'required': True, 'default': '-'}
+          'required': True, 'default': '-'},
+         {'name': 'availability', 'long_name': 'What days can they work?',
+          'attr_type': 'select_multiple',
+          'choices': ['Monday', 'Tuesday', 'Wednesday', 'Thursday',
+                      'Friday', 'Saturday', 'Sunday'],
+          'required': True, 'default': '[]'}
      ]},
     {'content_type': 'party',
      'selectors': ('Civil', 'Bridges'),

--- a/jsonattrs/models.py
+++ b/jsonattrs/models.py
@@ -237,7 +237,14 @@ class Attribute(models.Model):
                 params={'field': self.name}
             )
         if self.choices is not None and self.choices != []:
-            if value not in self.choices:
+            if type(value) == list:
+                for v in value:
+                    if v not in self.choices:
+                        raise ValidationError(
+                            _('Invalid choice for %(field)s: "%(value)s"'),
+                            params={'field': self.name, 'value': v}
+                        )
+            elif value not in self.choices:
                 raise ValidationError(
                     _('Invalid choice for %(field)s: "%(value)s"'),
                     params={'field': self.name, 'value': value}

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -47,7 +47,12 @@ DEFAULT_SCHEMATA = [
           'choices': ['none', 'text', 'point', 'polygon_low', 'polygon_high'],
           'choice_labels': ['None', 'Textual', 'Point geometry',
                             'Low-resolution polygon geometry',
-                            'High-resolution polygon geometry']}
+                            'High-resolution polygon geometry']},
+         {'name': 'infrastructure', 'long_name': 'What structures are nearby?',
+          'attr_type': 'select_multiple', 'default': 'none', 'required': False,
+          'choices': ['water', 'transportation', 'food', 'sanitation'],
+          'choice_lables': ['Water', 'Transportation', 'Food',
+                            'Sanitation Facilities']}
      ]}
 ]
 

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -82,12 +82,28 @@ class FieldAttributeTest(FieldTestBase):
             project=self.fixtures['proj11'],
             address='Bag End, Hobbiton', attrs={'quality': 'point'}
         )
-        assert len(tstparcel1.attrs.attributes) == 1
+        assert len(tstparcel1.attrs.attributes) == 2
         assert tstparcel1.attrs['quality'] == 'point'
         with pytest.raises(ValidationError):
             Parcel.objects.create(
                 project=self.fixtures['proj11'],
                 address='Bag End, Hobbiton', attrs={'quality': 'foo'}
+            )
+
+        tstparcel2 = Parcel.objects.create(
+            project=self.fixtures['proj11'],
+            address='The Shire',
+            attrs={
+                'quality': 'point',
+                'infrastructure': ['water', 'food']
+                }
+        )
+        assert len(tstparcel1.attrs.attributes) == 2
+        assert tstparcel2.attrs['infrastructure'] == ['water', 'food']
+        with pytest.raises(ValidationError):
+            Parcel.objects.create(
+                project=self.fixtures['proj11'],
+                address='The Shire', attrs={'infrastructure': ['foo', 'bar']}
             )
 
     def test_attributes_required_validation(self):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -74,8 +74,9 @@ class FormCreationTest(FormTestBase):
         assert 'project' in form.fields
         assert 'type' in form.fields
         assert 'attrs::quality' in form.fields
+        assert 'attrs::infrastructure' in form.fields
         assert isinstance(form.fields['attrs::quality'], forms.ChoiceField)
-        assert len(form.fields) == 4
+        assert len(form.fields) == 5
         labels = [ch[1] for ch in form.fields['attrs::quality'].choices]
         assert 'None' in labels
         assert 'Textual' in labels
@@ -132,8 +133,9 @@ class FormCreationTest(FormTestBase):
         assert 'project' in form.fields
         assert 'type' in form.fields
         assert 'attrs::quality' in form.fields
+        assert 'attrs::infrastructure' in form.fields
         assert isinstance(form.fields['attrs::quality'], forms.ChoiceField)
-        assert len(form.fields) == 4
+        assert len(form.fields) == 5
 
     def test_create_bad_fieldname(self):
         create_attribute_type('bad', 'Bad', 'BadField')


### PR DESCRIPTION
The validator on `choices` would not allow anything besides strings. Added logic to check if the `value` was an array, and if the values inside that were legal choices.
