### PR TITLE
Add tox envs for Django 1.10 and 1.11; remove 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ addons:
 env:
   - TOX_ENV=py35-flake8
   - TOX_ENV=py35-docs
-  - TOX_ENV=py35-django1.9
+  - TOX_ENV=py35-django1.10
+  - TOX_ENV=py35-django1.11
 matrix:
   fast_finish: true
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -28,5 +28,5 @@ commands = make -C docs html
 deps =
        Sphinx>=1.3.3
        Django==1.11.4
-       djangorestframework==3.3.3
-       psycopg2==2.6.2
+       djangorestframework==3.6.3
+       psycopg2==2.7.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,16 @@
 [tox]
 envlist =
        py35-{flake8,docs},
-       py35-django1.9
+       py35-django1.10
+       py35-django1.11
 
 [testenv]
 commands = ./runtests.py --fast
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-       django1.9: Django==1.9
+       django1.10: Django>=1.10,<1.11
+       django1.11: Django>=1.11,<1.12
        pytest-django==3.1.2
        psycopg2==2.7.3
        factory-boy==2.9.2


### PR DESCRIPTION
Not much to add. Making sure that the Travis build runs against Django 1.10 and 1.11. Also removes support for Django 1.9 as it doesn't receive any further security updates. 