### PR TITLE
Discussion: Rm custom __getitem__ method?

### DIFF
--- a/jsonattrs/fields.py
+++ b/jsonattrs/fields.py
@@ -124,12 +124,6 @@ class JSONAttributes(UserDict):
         if key not in self._attrs and key not in self:
             raise KeyError(key)
 
-    def __getitem__(self, key):
-        if not self._setup:
-            self.setup_from_dict(self._db_val)
-        self._check_key(key)
-        return super().__getitem__(key)
-
     def __setitem__(self, key, value):
         if self._init_done:
             self._check_key(key)
@@ -201,14 +195,3 @@ class JSONAttributeField(JSONField):
         return (Json(dict(value), dumps=json_serialiser)
                 if isinstance(value, dict)
                 else super().get_prep_lookup(lookup_type, value))
-
-    # def validate(self, value, model_instance):
-    #     super(JSONField, self).validate(value, model_instance)
-    #     try:
-    #         json.dumps(dict(value))
-    #     except TypeError:
-    #         raise exceptions.ValidationError(
-    #             self.error_messages['invalid'],
-    #             code='invalid',
-    #             params={'value': value},
-    #         )

--- a/jsonattrs/fields.py
+++ b/jsonattrs/fields.py
@@ -64,7 +64,8 @@ class JSONAttributes(UserDict):
 
     def _pre_save_selector_check(self, strict=False):
         if not self._setup:
-            self.setup_from_dict(self._db_val)
+            self.setup_from_dict(self._db_val if self._instance._state.adding
+                                 else self._get_from_instance())
         old_selectors = self._saved_selectors
         new_selectors = Schema.objects._get_selectors(self._instance)
         self._saved_selectors = new_selectors

--- a/jsonattrs/signals.py
+++ b/jsonattrs/signals.py
@@ -1,3 +1,5 @@
+import functools
+
 from django.core.exceptions import FieldError
 
 from .fields import JSONAttributes, JSONAttributeField
@@ -31,6 +33,8 @@ def fixup_instance(sender, **kwargs):
 
         # Cache model instance on JSONAttributes instance and vice-versa
         attrs._instance = instance
+        attrs._get_from_instance = functools.partial(
+            getattr, instance, field_name)
         instance._attr_field = attrs
 
     if not hasattr(instance, '_attr_field'):

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -4,6 +4,7 @@ from datetime import date, datetime
 from django.test import TestCase
 from django.core.exceptions import ValidationError
 
+from .factories import OrganizationFactory
 from .fixtures import create_fixtures
 from .models import Organization, Project, Party, Parcel
 from jsonattrs.fields import convert
@@ -180,6 +181,17 @@ class FieldAttributeTest(FieldTestBase):
         assert Party.objects.count() == 45
         print([(p.name, p.attrs) for p in Party.objects.all()])
         assert Party.objects.filter(attrs={'homeowner': 'False'}).count() == 5
+
+    def test_cast_to_dict_with_unknown_attr(self):
+        """
+        Ensure that data with unknown attributes can still be cast to dict.
+        This is used by DRF's JSONRenderer to render models with a
+        JSONAttribute field to JSON.
+        """
+        prj = Organization.objects.bulk_create([  # Skip validation on create
+            OrganizationFactory.build(attrs={'foo': 'bar'})
+        ])[0]
+        assert dict(prj.attrs) == {'foo': 'bar'}
 
 
 class FieldDbTest(FieldTestBase):


### PR DESCRIPTION
## Background

I've been working towards optimizing API endpoints in the Cadasta/cadasta-platform project.  When looking at the `parties` endpoint, I see a high number of queries when serializing a relatively small number of resources (note that the query is duplicated 30 times):

![screen shot 2018-01-08 at 11 58 04 am](https://user-images.githubusercontent.com/897290/34688759-6b01645e-f470-11e7-8911-9ae797064c9e.png)

It seems that in the process of the Django REST Framework serializing each resource into JSON, it casts the resource's `attributes` value to a `dict`.  I believe that Python's `dict` class initialization internally works something like this:

```py
self = {}
for key in input_data:
    self[key] = input_data[key]
```

Thus, we run `__getitem__` for every key in the `JSONAttributes` field.  This runs `self.setup_from_dict` on the first run, which is needed so that we may later run `self._check_key(key)`:

https://github.com/Cadasta/django-jsonattrs/blob/4f06cdea8dbe131aa78e1ac1b67cd9837d9ad038/jsonattrs/fields.py#L121-L125

`self.setup_from_dict()` runs `validate` on every element in its data, requiring a lookup of the `attr_type` foreign key:

https://github.com/Cadasta/django-jsonattrs/blob/4f06cdea8dbe131aa78e1ac1b67cd9837d9ad038/jsonattrs/fields.py#L27-L36
https://github.com/Cadasta/django-jsonattrs/blob/4f06cdea8dbe131aa78e1ac1b67cd9837d9ad038/jsonattrs/models.py#L294-L304

Thus, we're running 1 SQL query for every attribute of every resource being returned in the API. In the case of the API example above, the API is returning 10 resources that each have 3 attributes resulting in 30 separate queries.  Being that the API returns 100 resources by default and that resources often have more than 3 attributes, it's clear that this can quickly become a performance issue.

## Change

The simplest fix for this would be to remove the overridden `__getitem__` method for the `JSONAttributes` object.  **I'm not really sure what the purpose of running `self._check_key(key)` on reads from the object, so please let me know if this is a bad idea.**  Running validation on writes seems necessary, but I think we could get away from running it on reads.

After this change, our API problems went away:

![screen shot 2018-01-08 at 11 57 11 am](https://user-images.githubusercontent.com/897290/34690294-c78865d8-f475-11e7-8bad-dfd413fed494.png)
