### PR TITLE
Add link to example app and link to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,3 +2,5 @@ django-jsonattrs
 ================
 
 Django app to provide Postgres JSON-based attribute management.
+
+https://django-jsonattrs.readthedocs.io/

--- a/docs/source/example/index.rst
+++ b/docs/source/example/index.rst
@@ -8,4 +8,4 @@ The django-jsonattrs distribution includes a relatively comprehensive
 example application.  It's just basic CRUD + forms, but it serves to
 illustrate how to use the package.
 
-TBD
+`Link. <https://github.com/Cadasta/django-jsonattrs/tree/master/example>`_


### PR DESCRIPTION
I deployed this module's documentation to https://django-jsonattrs.readthedocs.io/.  This may have been a mistake given how scant the docs are, but at least they're up and we can possibly build them out over time.