### PR TITLE
Legibility improvements

### DIFF
--- a/jsonattrs/decorators.py
+++ b/jsonattrs/decorators.py
@@ -1,26 +1,6 @@
 from django.db.models.signals import post_init, pre_save
-from django.core.exceptions import FieldError
 
-from .fields import JSONAttributes, JSONAttributeField
-from .signals import attribute_model_pre_save
-
-
-def fixup_instance(sender, **kwargs):
-    instance = kwargs['instance']
-    for f in instance._meta.fields:
-        if isinstance(f, JSONAttributeField):
-            fi = getattr(instance, f.name)
-            if not isinstance(fi, JSONAttributes):
-                setattr(instance, f.name, JSONAttributes(fi))
-            fld = getattr(instance, f.name)
-            fld._instance = instance
-            if hasattr(instance, '_attr_field'):
-                raise FieldError('multiple JSONAttributeField fields: '
-                                 'only one is allowed per model!')
-            instance._attr_field = fld
-    if not hasattr(instance, '_attr_field'):
-        raise FieldError('missing JSONAttributeField field in '
-                         'fixup_instance decorator')
+from .signals import fixup_instance, attribute_model_pre_save
 
 
 def fix_model_for_attributes(cls):

--- a/jsonattrs/fields.py
+++ b/jsonattrs/fields.py
@@ -163,6 +163,10 @@ def choices_compatible(new_choices, old_choices, value):
 
 
 def convert(val):
+    # This is needed to provide JSON serialisation for date objects
+    # whenever they're saved to JSON attribute fields.  This function is
+    # passed as the custom "dumps" method for psycopg2's Json class to
+    # use.
     if isinstance(val, datetime) or isinstance(val, date):
         return val.isoformat()
     elif isinstance(val, Decimal):

--- a/jsonattrs/fields.py
+++ b/jsonattrs/fields.py
@@ -162,22 +162,6 @@ def choices_compatible(new_choices, old_choices, value):
     return new_choices is None or len(new_choices) == 0 or value in new_choices
 
 
-def schema_update_conflicts(instance):
-    if not hasattr(instance, '_attr_field'):
-        raise ValueError("instance doesn't have an attribute field")
-    conflicts = []
-    try:
-        instance._attr_field._pre_save_selector_check(strict=True)
-    except SchemaUpdateException as exc_info:
-        conflicts = exc_info.conflicts
-    return conflicts
-
-
-# This is needed to provide JSON serialisation for date objects
-# whenever they're saved to JSON attribute fields.  This function is
-# passed as the custom "dumps" method for psycopg2's Json class to
-# use.
-
 def convert(val):
     if isinstance(val, datetime) or isinstance(val, date):
         return val.isoformat()

--- a/jsonattrs/fields.py
+++ b/jsonattrs/fields.py
@@ -24,6 +24,9 @@ class JSONAttributes(UserDict):
         super().__init__(data, *args, **kwargs)
         self._init_done = True
 
+    def __repr__(self):
+        return "JSONAttributes({})".format(super().__repr__())
+
     def setup_from_dict(self, data_dict):
         self.setup_schema()
         if data_dict is None or len(data_dict) == 0:

--- a/jsonattrs/signals.py
+++ b/jsonattrs/signals.py
@@ -1,2 +1,38 @@
+from django.core.exceptions import FieldError
+
+from .fields import JSONAttributes, JSONAttributeField
+
+
 def attribute_model_pre_save(sender, **kwargs):
     kwargs['instance']._attr_field._pre_save_selector_check()
+
+
+def fixup_instance(sender, **kwargs):
+    """
+    Cache JSONAttributes data on instance and vice versa for convenience.
+    """
+    instance = kwargs['instance']
+    for model_field in instance._meta.fields:
+
+        if not isinstance(model_field, JSONAttributeField):
+            continue
+
+        if hasattr(instance, '_attr_field'):
+            raise FieldError('multiple JSONAttributeField fields: '
+                             'only one is allowed per model!')
+
+        field_name = model_field.name
+        attrs = getattr(instance, field_name)
+
+        # ensure JSONAttributeField's data is of JSONAttributes type
+        if not isinstance(attrs, JSONAttributes):
+            setattr(instance, field_name, JSONAttributes(attrs))
+            attrs = getattr(instance, field_name)
+
+        # Cache model instance on JSONAttributes instance and vice-versa
+        attrs._instance = instance
+        instance._attr_field = attrs
+
+    if not hasattr(instance, '_attr_field'):
+        raise FieldError('missing JSONAttributeField field in '
+                         'fixup_instance decorator')

--- a/tests/test_selector_update.py
+++ b/tests/test_selector_update.py
@@ -3,7 +3,6 @@ from django.test import TestCase
 from django.core.exceptions import ValidationError
 
 from jsonattrs.exceptions import SchemaUpdateConflict, SchemaUpdateException
-from jsonattrs.fields import schema_update_conflicts
 
 from .fixtures import create_fixtures, create_labelled_schemata
 from .models import Party, Labelled
@@ -184,60 +183,3 @@ class LabelledSelectorUpdateTest(LabelledModelTest):
     def test_change_choices_list_exclude_current(self):
         self.doit('change_choices',
                   present=('f1', 'f2', 'f3', 'f4'))
-
-
-class LabelledSchemaUpdateConflictCheckTest(LabelledModelTest):
-    def setUp(self):
-        super().setUp()
-        self.obj = Labelled.objects.create(
-            name='initial',
-            label='initial',
-            attrs={'f1': 'ABC', 'f2': 'f2_val', 'f3': 123, 'f4': 'def'}
-        )
-        self.check(('f1', 'f2', 'f3', 'f4'))
-
-    def doit(self, label, conflicts=[]):
-        self.obj.label = label
-        assert schema_update_conflicts(self.obj) == conflicts
-
-    def test_remove_non_required_field(self):
-        self.doit('remove_non_required')
-
-    def test_remove_required_field(self):
-        self.doit('remove_required')
-
-    def test_add_new_non_required_field(self):
-        self.doit('new_non_required')
-
-    def test_add_new_required_field_no_default(self):
-        self.doit('new_required_no_default',
-                  [SchemaUpdateConflict('f5', 'required_no_default')])
-
-    def test_add_new_required_field_default(self):
-        self.doit('new_required_default')
-
-    def test_change_field_type_compatible(self):
-        self.doit('type_compatible')
-
-    def test_change_field_type_incompatible(self):
-        self.doit('type_incompatible',
-                  [SchemaUpdateConflict('f2', 'incompatible_type')])
-
-    def test_remove_choices_list(self):
-        self.doit('remove_choices')
-
-    def test_add_choices_list_include_current(self):
-        self.doit('add_choices')
-
-    def test_add_choices_list_exclude_current(self):
-        self.obj.attrs['f1'] = 'XYZ'
-        self.doit('add_choices',
-                  [SchemaUpdateConflict('f1', 'incompatible_choices')])
-
-    def test_change_choices_list_include_current(self):
-        self.obj.attrs['f4'] = 'ghi'
-        self.doit('change_choices')
-
-    def test_change_choices_list_exclude_current(self):
-        self.doit('change_choices',
-                  [SchemaUpdateConflict('f4', 'incompatible_choices')])


### PR DESCRIPTION
Some cleanup:

- Mv `fixup_instance` to `signals.py`, as it is a signal handler
- Add a `__repr__` on `JSONAttributes` so that instances are easily discernible from `dict` instances
- Rm unused `schema_update_conflicts` functionality and related tests
- Docstring and variable name cleanup