### PR TITLE
Fixes #18 -- Raise ValidationError for unknown keys

### DIFF
--- a/jsonattrs/fields.py
+++ b/jsonattrs/fields.py
@@ -31,6 +31,9 @@ class JSONAttributes(UserDict):
         else:
             self._check_required_keys(data_dict.keys())
             for k, v in data_dict.items():
+                if k not in self._attrs.keys():
+                    raise ValidationError('Unknown key "{}"'.format(k))
+
                 self._check_key(k)
                 self._attrs[k].validate(v)
                 self[k] = v

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -28,7 +28,6 @@ def test_convert_unknown():
     val = ValidationError('Some Error')
     with pytest.raises(TypeError) as e:
         convert(val)
-    print(e.value)
     assert 'ValidationError can not be converted to JSON.' == str(e.value)
 
 
@@ -76,6 +75,14 @@ class FieldSchemaTest(FieldTestBase):
 
 
 class FieldAttributeTest(FieldTestBase):
+    def test_validate_unknown_key(self):
+        with pytest.raises(ValidationError) as e:
+            Organization.objects.create(
+                name='tstorg',
+                attrs={'home_office': 'London', 'unknown': False}
+            )
+        assert 'Unknown key "unknown"' in e.value
+
     def test_attributes_defaults(self):
         tstorg = Organization.objects.create(name='tstorg')
         assert len(tstorg.attrs.attributes) == 1
@@ -178,7 +185,6 @@ class FieldAttributeTest(FieldTestBase):
 
     def test_attributes_lookup_dict(self):
         assert Party.objects.count() == 45
-        print([(p.name, p.attrs) for p in Party.objects.all()])
         assert Party.objects.filter(attrs={'homeowner': 'False'}).count() == 5
 
 


### PR DESCRIPTION
Whenever a key is provided that is not defined in the corresponding schema, a `KeyError` is thrown.

The PR adds a check for this condition and raises `ValidationError`, which is easier to handle within a Django request cycle. 