### PR TITLE
Render None as empty string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.pytest_cache/
 
 # C extensions
 *.so

--- a/jsonattrs/models.py
+++ b/jsonattrs/models.py
@@ -358,6 +358,8 @@ class Attribute(models.Model):
             return {c: l for c, l in zip(self.choices, self.choice_labels)}
 
     def render(self, val):
+        if val is None:
+            return ''
         if self.choice_dict is None:
             return val
         else:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -99,3 +99,47 @@ class ComposeSchemaTest(TestCase):
         attr = Attribute(name='testattr', id=123)
         assert str(attr) == '<Attribute #123: name=testattr>'
         assert repr(attr) == '<Attribute #123: name=testattr>'
+
+
+class AttributeTest(TestCase):
+    def setUp(self):
+        self.fixtures = create_fixtures(do_schemas=False, load_attr_types=True)
+        self.schema = Schema.objects.create(
+            content_type=self.fixtures['party_t'], selectors=()
+        )
+
+    def test_render_integer(self):
+        attr_type = AttributeType.objects.get(name='integer')
+        attr = Attribute.objects.create(
+            schema_id=self.schema.id,
+            name='integer',
+            long_name='Test attribute integer',
+            index=0,
+            attr_type_id=attr_type.id,
+        )
+        assert attr.render(None) == ''
+        assert attr.render(12) == 12
+
+    def test_render_decimal(self):
+        attr_type = AttributeType.objects.get(name='decimal')
+        attr = Attribute.objects.create(
+            schema_id=self.schema.id,
+            name='decimal',
+            long_name='Test attribute decimal',
+            index=0,
+            attr_type_id=attr_type.id,
+        )
+        assert attr.render(None) == ''
+        assert attr.render(12.5) == 12.5
+
+    def test_render_date(self):
+        attr_type = AttributeType.objects.get(name='date')
+        attr = Attribute.objects.create(
+            schema_id=self.schema.id,
+            name='date',
+            long_name='Test attribute date',
+            index=0,
+            attr_type_id=attr_type.id,
+        )
+        assert attr.render(None) == ''
+        assert attr.render('2018-05-31') == '2018-05-31'


### PR DESCRIPTION
#### Why I made this change

If you add or edit a party on the platform and leave non-required fields blank, number and date fields , which are blank, are displayed as None. 

The `render` method of each attribute simply returns the value passed to the `val` parameter; for `None` values this results in "None" being displayed. 

#### Description of the change

If the provided value is `None` return an empty string (`''`)

#### How someone else can test the change

Install this branch in the platform.

Create a project using [this form](https://github.com/Cadasta/django-jsonattrs/files/2062655/e2i5dpffikimw5eggv9dftyq.xlsx). The form contains an `integer` field called `number_children` and a `date` field called `dob`. 

Create a party, choose the party type "Individual" leave both `number_children` and `dob` blank. After saving you should check on the party detail page that no value is displayed for both fields. 

### When should this PR be merged

This is somewhat urgent to one partner so we need to get it through quickly.

### Risks

None

### Follow-up actions

- Release a new version of django-jsonattrs
- Update the platform requirements to that new version